### PR TITLE
remove use of transactionEnabled that was deprecated and set transact…

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/mongock/MongockFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/mongock/MongockFactory.java
@@ -40,7 +40,7 @@ public class MongockFactory {
                 .setDriver(
                         MongoSync4Driver.withDefaultLock(mongoClient, databaseName))
                 .addMigrationClasses(migrationClasses)
-                .setTransactionEnabled(mongockRuntimeConfig.transactionEnabled())
+                .setTransactional(mongockRuntimeConfig.transactionEnabled())
                 // See https://github.com/mongock/mongock/issues/661
                 .setLockGuardEnabled(false)
                 .buildRunner();


### PR DESCRIPTION
…ional instead

use `setTransactional` instead of `setTransactionEnabled` to remove the warning that is logged by Mongock during init 

````
2025-02-05 08:29:43,590 WARN  [io.mon.api.con.MongockConfiguration] (main) 
********************************************************************************
PROPERTY [transactionEnabled] DEPRECATED. IT WILL BE REMOVED IN NEXT VERSIONS
Please use the following properties instead: [transactional]
********************************************************************************
```` 

property name not changed on purpose to avoid any migration within user code - in case the property has been used.