### PR TITLE
Use ConfigProvider to retrieve the default database name

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/mongock/deployment/MongockProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/mongock/deployment/MongockProcessor.java
@@ -23,7 +23,6 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.*;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
-import io.quarkus.mongodb.runtime.MongodbConfig;
 
 @BuildSteps(onlyIf = MongockEnabled.class)
 class MongockProcessor {
@@ -43,7 +42,6 @@ class MongockProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     void createBeans(MongockRecorder recorder,
-            MongodbConfig mongodbConfig,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer) {
 
         SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
@@ -52,7 +50,7 @@ class MongockProcessor {
                 .setRuntimeInit()
                 .unremovable()
                 .addInjectionPoint(ClassType.create(DotName.createSimple(MongoClient.class)))
-                .createWith(recorder.mongockFunction(mongodbConfig));
+                .createWith(recorder.mongockFunction());
 
         syntheticBeanBuildItemBuildProducer.produce(configurator.done());
     }

--- a/runtime/src/main/java/io/quarkiverse/mongock/MongockFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/mongock/MongockFactory.java
@@ -2,37 +2,35 @@ package io.quarkiverse.mongock;
 
 import java.util.List;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import com.mongodb.client.MongoClient;
 
 import io.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver;
 import io.mongock.runner.core.executor.MongockRunner;
 import io.mongock.runner.standalone.MongockStandalone;
 import io.quarkiverse.mongock.runtime.MongockRuntimeConfig;
-import io.quarkus.mongodb.runtime.MongodbConfig;
 
 public class MongockFactory {
 
     private final MongoClient mongoClient;
-
-    private final MongodbConfig mongodbConfig;
 
     private final MongockRuntimeConfig mongockRuntimeConfig;
     private final List<Class<?>> migrationClasses;
 
     public MongockFactory(
             MongoClient mongoClient,
-            MongodbConfig mongodbConfig,
             MongockRuntimeConfig mongockRuntimeConfig,
             List<Class<?>> migrationClasses) {
 
         this.mongoClient = mongoClient;
-        this.mongodbConfig = mongodbConfig;
         this.mongockRuntimeConfig = mongockRuntimeConfig;
         this.migrationClasses = migrationClasses;
     }
 
     public MongockRunner createMongockRunner() {
-        String databaseName = mongodbConfig.defaultMongoClientConfig.database
+
+        String databaseName = ConfigProvider.getConfig().getOptionalValue("quarkus.mongodb.database", String.class)
                 .orElseThrow(() -> new IllegalStateException("The database property was not configured for " +
                         "the default Mongo Client (via 'quarkus.mongodb.database')"));
 

--- a/runtime/src/main/java/io/quarkiverse/mongock/runtime/MongockRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/mongock/runtime/MongockRecorder.java
@@ -12,7 +12,6 @@ import io.quarkiverse.mongock.MongockFactory;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.arc.SyntheticCreationalContext;
-import io.quarkus.mongodb.runtime.MongodbConfig;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
@@ -34,10 +33,10 @@ public class MongockRecorder {
         MongockRecorder.migrationClasses = migrationClasses;
     }
 
-    public Function<SyntheticCreationalContext<MongockFactory>, MongockFactory> mongockFunction(MongodbConfig mongodbConfig) {
+    public Function<SyntheticCreationalContext<MongockFactory>, MongockFactory> mongockFunction() {
         return (SyntheticCreationalContext<MongockFactory> context) -> {
             MongoClient mongoClient = context.getInjectedReference(MongoClient.class);
-            return new MongockFactory(mongoClient, mongodbConfig, config.getValue(), migrationClasses);
+            return new MongockFactory(mongoClient, config.getValue(), migrationClasses);
         };
     }
 


### PR DESCRIPTION
Since Quarkus 3.19, mongodb-client switched to `@ConfigMapping`, it breaks the build of the extension (https://github.com/quarkusio/quarkus/pull/46070). 

This change should allow the extension to work with Quarkus 3.19 and older.